### PR TITLE
Allow system maps to contain arbitrary values

### DIFF
--- a/src/suspendable/core.clj
+++ b/src/suspendable/core.clj
@@ -25,8 +25,13 @@
 (defn- stop-missing-components [old-system new-system]
   (component/update-system old-system (missing-keys old-system new-system) component/stop))
 
+(defn- maybe-vary-meta [obj f & args]
+  (if (instance? clojure.lang.IObj obj)
+    (apply vary-meta obj f args)
+    obj))
+
 (defn- assoc-component-key [system key]
-  (update-in system [key] vary-meta assoc ::key key))
+  (update-in system [key] maybe-vary-meta assoc ::key key))
 
 (defn- resume-system-component [old-system component]
   (let [key (-> component meta ::key)]

--- a/test/suspendable/core_test.clj
+++ b/test/suspendable/core_test.clj
@@ -28,6 +28,15 @@
   (let [component (->PlainComponent)]
     (is (= (-> component (resume component) :state) :started))))
 
+(deftest test-components-that-arent-components
+  (let [system (component/start
+                (component/system-map
+                 :long 1
+                 :string "string"
+                 :false false))]
+    (is (suspend-system system))
+    (is (resume-system system system))))
+
 (deftest test-suspend-system
   (let [system (suspend-system
                 (component/start


### PR DESCRIPTION
Hey James,

I'm working with an app at the moment that uses longs and strings in a system definition. To move all of these into maps would be quite a big change, and interestingly it 'just works' with vanilla Component.

I've implemented a quick fix that skips associating metadata on anything that isn't a `clojure.java.IObj`, which should fix the issue. It's certainly fixed the basic tests I've added.

Wasn't sure exactly how you'd like the code structured. I opted for adding a couple of small functions rather than keeping all the logic in the original `assoc-component-key` function. Open to suggestions if you think there's a more readable way of factoring the code.

Hope you're well, and look forward to hearing from you!

James

---

Component allows users to put any value into a system map, and I have
seen configuration stored in a system accordingly.

``` clj
(defn make-system
  []
  (component/system-map :port 3000 :user "hickey")
```

This works with Component, but would previously result in an exception
when using Suspendable via reloaded.repl. To avoid associating meta data
on somethign that doesn't support it this change conditionally avoids
use of `vary-meta` when the component is not an instance of
`clojure.lang.IObj`.
