### PR TITLE
Add :extend-via-metadata to Suspendable protocol

### DIFF
--- a/src/suspendable/core.clj
+++ b/src/suspendable/core.clj
@@ -5,6 +5,7 @@
             [clojure.set :as set]))
 
 (defprotocol Suspendable
+  :extend-via-metadata true
   (suspend [component]
     "Suspend a component and return the suspended component. Expected to be
     called before a resume.")


### PR DESCRIPTION
Clojure 1.10 makes it possible to extend protocols via metadata. Adding this option to a protocol is backwards compatible according to the same change that was made to `com.stuartsierra.component`: stuartsierra/component@7824f55